### PR TITLE
fixed a case error

### DIFF
--- a/skCCM/__init__.py
+++ b/skCCM/__init__.py
@@ -1,1 +1,1 @@
-from .skccm import CCM, Embed
+from .skCCM import CCM, Embed


### PR DESCRIPTION
I was getting `ModuleNotFoundError: No module named 'skCCM.skccm'`.